### PR TITLE
[FEAT] #12 공통 Input 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "together",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.74.7",
         "axios": "^1.9.0",
@@ -1099,6 +1100,52 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1509,7 +1556,7 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
       "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.74.7",
     "axios": "^1.9.0",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface InputProps extends React.ComponentProps<'input'> {
+  inputSize?: 'md' | 'lg';
+  variant?: 'default' | 'underline';
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, inputSize = 'md', variant = 'default', ...props }, ref) => {
+    const baseStyle =
+      'flex w-full bg-white px-12 py-8 text-black border-gray-300 ' +
+      'placeholder:text-textSecondary focus:border-primary focus:outline-none disabled:opacity-50';
+
+    const sizeStyle = inputSize === 'lg' ? 'h-44 text-[1.8rem]' : 'h-40 text-[1.6rem]';
+
+    const variantStyle =
+      variant === 'underline'
+        ? 'border-b focus:border-b-2 rounded-none'
+        : 'border focus:border-2 rounded-6';
+
+    return (
+      <input
+        type={type}
+        className={cn(baseStyle, sizeStyle, variantStyle, className)}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+
+Input.displayName = 'Input';
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const labelVariants = cva('text-black leading-none peer-disabled:opacity-70', {
+  variants: {
+    size: {
+      lg: 'text-[1.8rem]',
+      md: 'text-[1.6rem]',
+      sm: 'text-[1.4rem]',
+    },
+  },
+
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+>(({ className, size, ...props }, ref) => (
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants({ size }), className)} {...props} />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };


### PR DESCRIPTION
### 🚀 작업 내용

공통 input 컴포넌트 및 label 컴포넌트 구현

- [x]  shadcn/ui input 기반 공통 input 컴포넌트 구현
- [x]  shadcn/ui label 기반 공통 label 컴포넌트 구현

### 🔍 리뷰 요청 사항
Input 요소에 라벨이 필요한 경우 label 컴포넌트를 별도로 사용해야 합니다.

![image](https://github.com/user-attachments/assets/2015bb4f-45f5-4dbf-b959-58bbc7deae1c)

### 📝 연관 이슈
close https://github.com/Middle-Project-02/FrontEnd/issues/12
