### PR TITLE
[FEAT] #20 공통 Badge 컴포넌트 구현

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center px-12 py-2 rounded-full font-semibold transition-colors',
+  {
+    variants: {
+      variant: {
+        default: '',
+        outline: '',
+      },
+      color: {
+        default: '',
+        primary: '',
+      },
+      size: {
+        lg: 'text-[1.8rem]',
+        md: 'text-[1.6rem]',
+        sm: 'text-[1.4rem]',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      color: 'default',
+      size: 'md',
+    },
+    compoundVariants: [
+      {
+        variant: 'default',
+        color: 'default',
+        className: 'bg-black text-white border-transparent',
+      },
+      {
+        variant: 'default',
+        color: 'primary',
+        className: 'bg-primary text-white border-transparent',
+      },
+      {
+        variant: 'outline',
+        color: 'default',
+        className: 'border-2 border-black text-black',
+      },
+      {
+        variant: 'outline',
+        color: 'primary',
+        className: 'border-2 border-primary text-primary',
+      },
+    ],
+  },
+);
+
+export interface BadgeProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, color, size, ...rest }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant, color, size }), className)} {...rest} />;
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
### 🚀 작업 내용

공통 Badge 컴포넌트 구현

- [x] shadcn/ui badge 기반 공통 badge 컴포넌트 구현

### 🔍 리뷰 요청 사항

Badge 컴포넌트의 hover 스타일은 사용하는 쪽에서 className을 통해 지정해 주세요.
Figma 디자인 값은 기준으로 참고하되, 실제 UI에서 부자연스럽게 보이는 border 두께 및 padding 값은 조정했습니다.

![image](https://github.com/user-attachments/assets/678cc04c-7605-43df-a1cd-bae6565c5f26)

### 📝 연관 이슈
close https://github.com/Middle-Project-02/FrontEnd/issues/20
