### PR TITLE
[FEAT] #28 공통 Modal 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
 import AppRouter from './AppRouter';
+import ModalContainer from '@/components/common/ModalContainer';
 
 function App() {
-  return <AppRouter />;
+  return (
+    <>
+      <AppRouter />
+      <ModalContainer />
+    </>
+  );
 }
 
 export default App;

--- a/src/components/common/ModalContainer.tsx
+++ b/src/components/common/ModalContainer.tsx
@@ -1,0 +1,30 @@
+import { useRef, useEffect } from 'react';
+import useModalStore from '@/stores/modalStore';
+
+const ModalContainer = () => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const { modal, removeModal } = useModalStore();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        removeModal();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [removeModal]);
+
+  return (
+    modal && (
+      <div className="fixed inset-0 z-[1000] bg-black/40 flex items-center justify-center">
+        <div className="bg-white px-20 py-30 rounded-16 w-[300px]" ref={modalRef}>
+          {modal}
+        </div>
+      </div>
+    )
+  );
+};
+
+export default ModalContainer;

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import { create } from 'zustand';
+
+interface ModalState {
+  modal: ReactNode;
+  setModal: (modal: ReactNode) => void;
+  removeModal: () => void;
+}
+
+const useModalStore = create<ModalState>((set) => ({
+  modal: null,
+  setModal: (modal) => set({ modal }),
+  removeModal: () => set({ modal: null }),
+}));
+
+export default useModalStore;


### PR DESCRIPTION
### 🚀 작업 내용

- [x] Modal 상태 관리를 위한 modalStore 구현
- [x] 모달창의 렌더링 위치를 제어하기 위한 ModalContainer 컴포넌트 구현 

### 🔍 리뷰 요청 사항
**modal 사용법**
```typescript
import useModalStore from '@/stores/modalStore';

const { setModal } = useModalStore();

// 모달 생성
setModal(<Modal 컴포넌트>) 
Ex) setModal(<DeleteModal />)
```
- `setModal`
    - 현재 모달 상태를 보여주고자 하는 모달창으로 설정합니다.
- `removeModal`
    - 현재 모달 상태를 초기화합니다.

![image](https://github.com/user-attachments/assets/7c5e7f74-b518-4709-ba41-43359a9d9a4e)

### 📝 연관 이슈
close https://github.com/Middle-Project-02/FrontEnd/issues/28
