### PR TITLE
[FEAT] #48 알림장 페이지 skeleton 추가

### DIFF
--- a/src/components/skeleton/notification/NotificationDetailSkeleton.tsx
+++ b/src/components/skeleton/notification/NotificationDetailSkeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import NotificationSectionSkeleton from './NotificationSectionSkeleton';
+import BackButton from '@/components/common/BackButton';
+
+const NotificationDetailSkeleton = () => (
+  <div className="flex flex-col h-full min-h-screen bg-white break-keep">
+    <header className="sticky top-0 px-[30px] pt-[44px] bg-white z-10">
+      <BackButton />
+      {/* title */}
+      <Skeleton className="h-[40px] w-full my-4 bg-bgSecondary" />
+      {/* tags */}
+      <div className="flex gap-3 flex-wrap pb-12">
+        <Skeleton className="w-[80px] h-[30px] rounded-full bg-bgSecondary" />
+        <Skeleton className="w-[70px] h-[30px] rounded-full bg-bgSecondary" />
+      </div>
+    </header>
+
+    <main className="flex flex-col items-center pb-[100px] flex-1 overflow-y-auto p-[30px] bg-bgTertiary no-scrollbar">
+      {[...Array(3)].map((_, i) => (
+        <NotificationSectionSkeleton key={i} />
+      ))}
+    </main>
+  </div>
+);
+
+export default NotificationDetailSkeleton;

--- a/src/components/skeleton/notification/NotificationSectionSkeleton.tsx
+++ b/src/components/skeleton/notification/NotificationSectionSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+const NotificationSectionSkeleton = () => (
+  <section className="mb-[16px] w-full max-w-[500px]">
+    {/* icon + title */}
+    <div className="flex items-center gap-[6px] mb-[12px]">
+      <Skeleton className="h-[30px] w-[30px] rounded-full bg-bgSecondary" />
+      <Skeleton className="h-[30px] w-[180px] bg-bgSecondary" />
+    </div>
+
+    {/* content */}
+    <div className="bg-white rounded-16 border shadow4 py-20 px-16 text-body-lg">
+      <Skeleton className="h-[24px] w-full mb-3 bg-bgSecondary" />
+      <Skeleton className="h-[24px] w-[90%] mb-3 bg-bgSecondary" />
+      <Skeleton className="h-[24px] w-[80%] bg-bgSecondary" />
+    </div>
+  </section>
+);
+
+export default NotificationSectionSkeleton;

--- a/src/components/skeleton/notification/NotificationSkeleton.tsx
+++ b/src/components/skeleton/notification/NotificationSkeleton.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+const NotificationCardSkeleton = () => (
+  <div className="w-full max-w-[500px] bg-white rounded-16 border shadow4 py-20 px-16 mb-5">
+    {/* title */}
+    <Skeleton className="h-[30px] w-4/5 mb-3 bg-bgSecondary" />
+
+    {/* tags */}
+    <div className="flex gap-2 mb-5 h-[30px]">
+      <Skeleton className="w-[80px] rounded-full bg-bgSecondary" />
+      <Skeleton className="w-[70px] rounded-full bg-bgSecondary" />
+    </div>
+
+    {/* summary */}
+    <Skeleton className="h-[24px] w-full mb-2 bg-bgSecondary" />
+    <Skeleton className="h-[24px] w-5/6 mb-4 bg-bgSecondary" />
+
+    {/* button */}
+    <div className="flex justify-end">
+      <Skeleton className="h-[36px] w-[96px] rounded-md bg-bgSecondary" />
+    </div>
+  </div>
+);
+
+export default NotificationCardSkeleton;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/pages/NotificationDetailPage.tsx
+++ b/src/pages/NotificationDetailPage.tsx
@@ -3,7 +3,7 @@ import { useNotificationDetailQuery } from '@/hooks/queries/notification/useNoti
 import { NOTIFICATION_DETAIL_SECTIONS } from '@/constants/notification';
 import BackButton from '@/components/common/BackButton';
 import { Badge } from '@/components/ui/badge';
-import Loading from '@/components/common/Loading';
+import NotificationDetailSkeleton from '@/components/skeleton/notification/NotificationDetailSkeleton';
 import NotificationSection from '@/components/notification/NotificationSection';
 import NotFoundPage from './NotFoundPage';
 
@@ -11,13 +11,9 @@ const NotificationDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const { notificationDetail, isLoading } = useNotificationDetailQuery(id!);
 
-  if (isLoading) {
-    return <Loading />;
-  }
+  if (isLoading) return <NotificationDetailSkeleton />;
 
-  if (!notificationDetail) {
-    return <NotFoundPage />;
-  }
+  if (!notificationDetail) return <NotFoundPage />;
 
   return (
     <div className="flex flex-col h-full min-h-screen bg-white break-keep">
@@ -33,7 +29,7 @@ const NotificationDetailPage = () => {
         </div>
       </header>
 
-      <main className="flex flex-col items-center flex-1 overflow-y-auto p-[30px] bg-bgTertiary no-scrollbar">
+      <main className="flex flex-col items-center pb-[100px] flex-1 overflow-y-auto p-[30px] bg-bgTertiary no-scrollbar">
         {NOTIFICATION_DETAIL_SECTIONS.map((section) => (
           <NotificationSection
             key={section.key}

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -3,7 +3,7 @@ import { PATH } from '@/constants/path';
 import { useAllNotificationsQuery } from '@/hooks/queries/notification/useNotificationQuery';
 import NotificationCard from '@/components/notification/NotificationCard';
 import BackButton from '@/components/common/BackButton';
-import Loading from '@/components/common/Loading';
+import NotificationCardSkeleton from '@/components/skeleton/notification/NotificationSkeleton';
 import NotFoundPage from './NotFoundPage';
 
 const NotificationPage = () => {
@@ -13,18 +13,13 @@ const NotificationPage = () => {
   const handleNotificationClick = (id: number) => {
     navigate(`${PATH.NOTIFICATIONS}/${id}`);
   };
-
-  if (isLoading) {
-    return <Loading />;
-  }
-
   if (!notifications) {
     return <NotFoundPage />;
   }
 
   return (
     <div className="flex flex-col h-full min-h-screen bg-white break-keep">
-      <header className="sticky top-0  px-[30px] pt-[44px]">
+      <header className="sticky top-0 px-[30px] pt-[44px]">
         <BackButton />
         <h3 className="text-heading-h3 font-semibold py-4">알림장</h3>
         <p className="text-body-md text-textSecondary pb-12">
@@ -33,16 +28,18 @@ const NotificationPage = () => {
         </p>
       </header>
 
-      <main className="flex flex-col items-center flex-1 overflow-y-auto p-[30px] bg-bgTertiary no-scrollbar">
-        {notifications?.map((notification) => (
-          <NotificationCard
-            key={notification.notificationId}
-            title={notification.title}
-            tags={notification.tags || []}
-            summary={notification.summary}
-            onDetailClick={() => handleNotificationClick(notification.notificationId)}
-          />
-        ))}
+      <main className="flex flex-col flex-1 pb-[100px] overflow-y-auto p-[30px] bg-bgTertiary no-scrollbar">
+        {isLoading
+          ? [...Array(4)].map((_, i) => <NotificationCardSkeleton key={i} />)
+          : notifications.map((notification) => (
+              <NotificationCard
+                key={notification.notificationId}
+                title={notification.title}
+                tags={notification.tags || []}
+                summary={notification.summary}
+                onDetailClick={() => handleNotificationClick(notification.notificationId)}
+              />
+            ))}
       </main>
     </div>
   );

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -4,7 +4,6 @@ import { useAllNotificationsQuery } from '@/hooks/queries/notification/useNotifi
 import NotificationCard from '@/components/notification/NotificationCard';
 import BackButton from '@/components/common/BackButton';
 import NotificationCardSkeleton from '@/components/skeleton/notification/NotificationSkeleton';
-import NotFoundPage from './NotFoundPage';
 
 const NotificationPage = () => {
   const { notifications, isLoading } = useAllNotificationsQuery();
@@ -13,9 +12,6 @@ const NotificationPage = () => {
   const handleNotificationClick = (id: number) => {
     navigate(`${PATH.NOTIFICATIONS}/${id}`);
   };
-  if (!notifications) {
-    return <NotFoundPage />;
-  }
 
   return (
     <div className="flex flex-col h-full min-h-screen bg-white break-keep">
@@ -31,7 +27,7 @@ const NotificationPage = () => {
       <main className="flex flex-col flex-1 pb-[100px] overflow-y-auto p-[30px] bg-bgTertiary no-scrollbar">
         {isLoading
           ? [...Array(4)].map((_, i) => <NotificationCardSkeleton key={i} />)
-          : notifications.map((notification) => (
+          : notifications?.map((notification) => (
               <NotificationCard
                 key={notification.notificationId}
                 title={notification.title}


### PR DESCRIPTION
### 🚀 작업 내용
- [x] shadcn Skeleton 컴포넌트 추가
- [x] 알림장 전체 조회/상세 조회 페이지 Skeleton UI 추가 

### 🔍 리뷰 요청 사항
- 알림장이 하나도 없을 때 알림장이 없습니다 등의 안내를 하게 되면 코드상에서 삼항 연산자 중첩 사용을 하게 되어 알림장은 사용자가 작성할 수 없고 어드민만(지금은 임의로 DB에 넣고 사용) 작성 가능하다는 특성 상 별도 안내는 하지 않도록 하였습니다!
- 원래는 템플릿 페이지도 함께 적용해서 올리려고 하였으나 현재 템플릿 페이지 관련 PR을 머지하지 않은 상태이며
  템플릿 페이지는 추후 삭제 모달도 추가해야하기에 그때 Skeleton까지 함께 적용해서 올리겠습니다! (이슈에 적어놓겠습니다!)

### 📝 연관 이슈
> close #48 
