### PR TITLE
[FEAT] #60 템플릿 저장 토스트 알림 추가

### DIFF
--- a/src/hooks/queries/template/useTemplateQueries.ts
+++ b/src/hooks/queries/template/useTemplateQueries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteTemplate, getTemplateDetail, getTemplates, postSaveTemplate } from '@/apis/template';
 import { Template, TemplateSaveRequest } from '@/types/template';
+import { makeToast } from '@/utils/makeToast';
 
 export const useTemplatesQuery = () => {
   const { data: templates, isLoading } = useQuery<Template[]>({
@@ -46,8 +47,12 @@ export const useDeleteTemplateMutation = ({ onSuccess, onError }: MutationHandle
     mutationFn: (id: number) => deleteTemplate(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['templates'] });
+      makeToast('안내서가 저장되었습니다.', 'success');
       onSuccess?.();
     },
-    onError,
+    onError: () => {
+      makeToast('안내서 저장에 실패했습니다. 다시 시도해주세요.', 'warning');
+      onError?.();
+    },
   });
 };


### PR DESCRIPTION
### 🚀 작업 내용
- [x] `useSaveTemplateMutation`의 `onSuccess`, `onError`에 `makeToast`로 템플릿 저장 성공, 실패 여부 알림 
<img width="300" alt="스크린샷 2025-06-23 오전 2 43 53" src="https://github.com/user-attachments/assets/2af4e98a-1051-489b-93a8-304d90a12fd4" />

### 🔍 리뷰 요청 사항
- 챗봇 구현 브랜치에서 토스트 잘 뜨는 것 확인하였습니다!
- 스크린샷과 코드상에서의 토스트 알림 메시지가 약간 다릅니다.. 스크린샷 찍고 나서 '요금제 변경 안내서' -> '안내서'로 수정했습니다! 
- 챗봇 페이지의 함수 최상단에 `useTemplateAutoSave()` 추가해주어야 템플릿 내용이 보내지면 저장 API가 호출됩니다! 테스트 시 참고해주세요!! 

### 📝 연관 이슈
> close #60
