### PR TITLE
[FEAT] #66 템플릿 자동 저장 기능 추가

### DIFF
--- a/src/pages/PlanChatBotPage.tsx
+++ b/src/pages/PlanChatBotPage.tsx
@@ -4,6 +4,7 @@ import { END_POINTS } from '@/constants/api';
 import { PATH } from '@/constants/path';
 import { SmartChoicePlanDto } from '@/types/smartChoicePlan';
 import { makeToast } from '@/utils/makeToast';
+import { useTemplateAutoSave } from '@/hooks/useTemplateAutoSave';
 import { useSse } from '@/hooks/sse/useSse';
 import { useSseListener } from '@/hooks/sse/useSseListener';
 import { useSpeechRecognition } from '@/hooks/chat/useSpeechRecognition';
@@ -25,6 +26,8 @@ const PlanChatBotPage = () => {
   const { mutate: sendChat } = useSendChatMessageMutation();
   const bottomRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
+
+  useTemplateAutoSave();
 
   const {
     isListening,


### PR DESCRIPTION
### 🚀 작업 내용
- 템플릿 생성하기 버튼(UI상에선 요금제 변경 안내서) 누르면 요금제 자동 저장 되도록 `useTemplateAutoSave()`를 챗봇페이지에 적용

### 🔍 리뷰 요청 사항
- 만약 `useTemplateAutoSave()`가 추가되었는데 템플릿이 저장에 실패했다는 토스트 알림이 뜨면 DB의 template 테이블을 확인해주세요!
  - template 테이블은 아래처럼 template_id, member_id, title, content만 존재해야합니다.. 만약 id, created_at, chat_id 등등이 있다면 drop column 해주세요!
<img width="182" alt="스크린샷 2025-06-24 오전 1 46 13" src="https://github.com/user-attachments/assets/609e8e14-cfa7-4b11-872c-965ea379f41c" />


### 📝 연관 이슈
> close #66 
