### PR TITLE
[FEAT] #68 추천받은 요금제 공유하기 기능 추가 

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <script
+      src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js"
+      integrity="sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6"
+      crossorigin="anonymous"
+    ></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/chat/KakaoShareButton.tsx
+++ b/src/components/chat/KakaoShareButton.tsx
@@ -1,0 +1,17 @@
+import { SmartChoicePlanDto } from '@/types/smartChoicePlan';
+import { useKakaoShare } from '@/hooks/useKakaoShare';
+import { Button } from '@/components/ui/button';
+
+const KakaoShareButton = ({ planInfo }: { planInfo: SmartChoicePlanDto }) => {
+  const { share } = useKakaoShare(planInfo);
+
+  return (
+    <>
+      <Button onClick={share} variant="outline" outlineColor="primary" className="w-full">
+        요금제 공유하기
+      </Button>
+    </>
+  );
+};
+
+export default KakaoShareButton;

--- a/src/components/chat/PlanCard.tsx
+++ b/src/components/chat/PlanCard.tsx
@@ -1,5 +1,5 @@
 import type { SmartChoicePlanDto } from '@/types/smartChoicePlan';
-import { Button } from '@/components/ui/button';
+import KakaoShareButton from '@/components/chat/KakaoShareButton';
 
 interface PlanCardProps {
   plan: SmartChoicePlanDto;
@@ -30,9 +30,7 @@ const PlanCard = ({ plan }: PlanCardProps) => {
         월 {plan.price.toLocaleString()}원
       </footer>
 
-      <Button variant="outline" outlineColor="primary" className="w-full">
-        요금제 공유하기
-      </Button>
+      <KakaoShareButton planInfo={plan} />
     </div>
   );
 };

--- a/src/hooks/useKakaoShare.ts
+++ b/src/hooks/useKakaoShare.ts
@@ -1,0 +1,79 @@
+import { useEffect } from 'react';
+import { SmartChoicePlanDto } from '@/types/smartChoicePlan';
+import { makeToast } from '@/utils/makeToast';
+
+declare global {
+  interface Window {
+    Kakao: any;
+  }
+}
+
+export const useKakaoShare = (planInfo: SmartChoicePlanDto) => {
+  const key = import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY;
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.Kakao && !window.Kakao.isInitialized()) {
+      window.Kakao.init(key);
+    }
+  }, [key]);
+
+  const handleFallbackShare = () => {
+    const message = `${planInfo.planName} 요금제 어때요?
+💰 월 ${planInfo.price.toLocaleString()}원
+📊 데이터: ${planInfo.data}
+📞 통화: ${planInfo.voice}
+💬 문자: ${planInfo.sms}
+📡 통신망: ${planInfo.telecom}
+
+이 요금제 괜찮은가요?`;
+
+    if (navigator.share) {
+      navigator
+        .share({
+          title: '요금제 추천 받았어요!',
+          text: message,
+        })
+        .catch(() => {
+          makeToast('공유가 어려워요.', 'warning');
+        });
+    } else {
+      makeToast('공유가 지원되지 않는 환경이에요', 'warning');
+    }
+  };
+
+  const share = () => {
+    const isKakaoReady =
+      typeof window !== 'undefined' &&
+      window.Kakao &&
+      typeof window.Kakao.isInitialized === 'function' &&
+      window.Kakao.isInitialized();
+
+    if (!isKakaoReady) {
+      makeToast('카카오톡 공유 기능이 준비되지 않았어요.', 'warning');
+      handleFallbackShare();
+      return;
+    }
+
+    try {
+      window.Kakao.Share.sendDefault({
+        objectType: 'feed',
+        content: {
+          title: `${planInfo.planName} 요금제 어때요?`,
+          description: `월 ${planInfo.price.toLocaleString()}원
+통신망: ${planInfo.telecom}, 데이터: ${planInfo.data}
+통화: ${planInfo.voice}, 문자: ${planInfo.sms}
+`,
+          imageUrl: 'https://i.ibb.co/23PJnGvY/0b5e446d-1e4b-4bed-92a4-cd2ce23e62fd.png',
+          link: {
+            mobileWebUrl: 'https://together2.netlify.app/',
+            webUrl: 'https://together2.netlify.app/',
+          },
+        },
+      });
+    } catch (e) {
+      console.error('카카오톡 공유 중 오류 발생:', e);
+      handleFallbackShare();
+    }
+  };
+  return { share };
+};


### PR DESCRIPTION
### 🚀 작업 내용
- [x] 추천받은 요금제 카카오톡 공유하기 기능 추가

<img width="246" alt="스크린샷 2025-06-24 오후 12 48 06" src="https://github.com/user-attachments/assets/2d4696f1-4d64-4340-9f4c-529c38208cc9" />

- [x] 카카오톡 공유하기 기능이 실패 시 Web Share API로 대체 공유 기능 추가 구현

<div>
<img width="350" alt="스크린샷 2025-06-24 오후 12 37 40" src="https://github.com/user-attachments/assets/9f1a2222-7158-416b-b2ab-203b88182323" />
<img width="350" alt="스크린샷 2025-06-24 오후 12 48 44" src="https://github.com/user-attachments/assets/46f0ffb8-bc01-4aff-a715-9bf34b80d510" />
</div>


### 🔍 리뷰 요청 사항
- 노션 secrets 페이지에서 .env 파일 확인 부탁드립니다! `VITE_KAKAO_JAVASCRIPT_KEY`가 추가되었습니다!
- 카카오톡 공유하기 기능을 사용할 수 없는 사용자들에게 toast로 공유할 수 없다는 알림만 제공하기 보다는, Web Share API를 이용하여 문자 등으로 대체 공유할 수 있는 기능을 추가로 구현하였습니다. 이 부분에 대해서 어떻게 생각하시는지, 그냥 알림만 제공하는게 나을지, 아니면 더 나은 대안이 있는지 의견 주시면 감사하겠습니다!
- 카카오톡 공유하기 할 때 같이 보내지는 이미지가 마음에 썩..드는게 없어서 우선 임시로 해놨습니다..

### 📝 연관 이슈
> close #68 
